### PR TITLE
Revert "No new routes if openvpn is already running."

### DIFF
--- a/src/se/leap/openvpn/OpenVpnManagementThread.java
+++ b/src/se/leap/openvpn/OpenVpnManagementThread.java
@@ -333,8 +333,7 @@ public class OpenVpnManagementThread implements Runnable {
 			mOpenVPNService.setDomain(extra);
 		} else if (needed.equals("ROUTE")) {
 			String[] routeparts = extra.split(" ");
-			if(!mOpenVPNService.isRunning()) // We cannot add routes to an existing openvpn session
-				mOpenVPNService.addRoute(routeparts[0], routeparts[1]);
+			mOpenVPNService.addRoute(routeparts[0], routeparts[1]);
 		} else if (needed.equals("ROUTE6")) {
 			mOpenVPNService.addRoutev6(extra);
 		} else if (needed.equals("IFCONFIG")) {


### PR DESCRIPTION
This reverts commit 5b772c23c3f45405f30de4a180fe47dbcb2fdfc4.

Because the OpenVpnService we are configuring is running, isRunning() always returns true, routes are never set, and no traffic ever goes over the VPN tunnel.  I should have caught this before i merged it before.
