### PR TITLE
Settings button moved to overflow.

### DIFF
--- a/res/menu/client_dashboard.xml
+++ b/res/menu/client_dashboard.xml
@@ -3,7 +3,6 @@
     <item
         android:id="@+id/menu_settings"
         android:orderInCategory="100"
-        android:icon="@drawable/ic_menu_settings_holo_light"
         android:title="@string/menu_settings"/>
     <item
         android:id="@+id/about_leap"


### PR DESCRIPTION
Icon resource left, just in case we need it in the future (overflow
items with icon? google?).
