### PR TITLE
No sharedprefs methods in ConfigHelper.

### DIFF
--- a/src/se/leap/bitmaskclient/ConfigHelper.java
+++ b/src/se/leap/bitmaskclient/ConfigHelper.java
@@ -47,141 +47,11 @@ import android.util.Base64;
  *
  */
 public class ConfigHelper {
-    
-    public static SharedPreferences shared_preferences;
     private static KeyStore keystore_trusted;
 
     final public static String NG_1024 =
     		"eeaf0ab9adb38dd69c33f80afa8fc5e86072618775ff3c0b9ea2314c9c256576d674df7496ea81d3383b4813d692c6e0e0d5d8e250b98be48e495c1d6089dad15dc7d7b46154d6b6ce8ef4ad69b15d4982559b297bcf1885c529f566660e57ec68edbc3c05726cc02fd4cbf4976eaa9afd5138fe8376435b9fc61d2fc0eb06e3";
     final public static BigInteger G = new BigInteger("2");
-	
-    
-    private static boolean checkSharedPrefs() {
-    	try {
-    		if(shared_preferences == null)
-    			shared_preferences = Dashboard.getAppContext().getSharedPreferences(Dashboard.SHARED_PREFERENCES,Context.MODE_PRIVATE);
-    	} catch (Exception e) {
-    		return false;
-    	}
-    	
-    	return true;
-    }
-    
-    /**
-     * Saves a JSON object into class scope Shared Preferences
-     * @param shared_preferences_key
-     * @param content
-     */
-	public static void saveSharedPref(String shared_preferences_key, JSONObject content) {
-
-		SharedPreferences.Editor shared_preferences_editor = shared_preferences
-				.edit();
-		shared_preferences_editor.putString(shared_preferences_key,
-				content.toString());
-		shared_preferences_editor.commit();
-	}
-
-    /**
-     * Saves a String object into class scope Shared Preferences
-     * @param shared_preferences_key
-     * @param content
-     */
-	public static void saveSharedPref(String shared_preferences_key, String content) {
-
-		SharedPreferences.Editor shared_preferences_editor = shared_preferences
-				.edit();
-		shared_preferences_editor.putString(shared_preferences_key,
-				content);
-		shared_preferences_editor.commit();
-	}
-
-    /**
-     * Saves a boolean object into class scope Shared Preferences
-     * @param shared_preferences_key
-     * @param content
-     */
-	public static void saveSharedPref(String shared_preferences_key, boolean content) {
-
-		SharedPreferences.Editor shared_preferences_editor = shared_preferences
-				.edit();
-		shared_preferences_editor.putBoolean(shared_preferences_key, content);
-		shared_preferences_editor.commit();
-	}
-	
-	/**
-	 * Saves an int into class scope Shared Preferences
-	 * 
-	 * @param shared_preferences_key
-	 * @param value
-	 */
-	protected static void saveSharedPref(String shared_preferences_key, int value) {
-		SharedPreferences.Editor shared_preferences_editor = shared_preferences.edit();
-		shared_preferences_editor.putInt(shared_preferences_key, value).commit();
-	}
-	
-	/**
-	 * Gets String object from class scope Shared Preferences
-	 * @param shared_preferences_key
-	 * @return the string correspondent to the key parameter
-	 */
-	public static String getStringFromSharedPref(String shared_preferences_key) {
-		String content = null;
-		content = shared_preferences.getString(shared_preferences_key, "");
-		return content;
-	}
-	
-	/**
-	 * Gets JSON object from class scope Shared Preferences
-	 * @param shared_preferences_key
-	 * @return the JSON object correspondent to the key parameter
-	 */
-	public static JSONObject getJsonFromSharedPref(String shared_preferences_key) throws JSONException {
-		JSONObject content = null;
-		if ( checkSharedPrefs() ) {
-			String json_string = shared_preferences.getString(shared_preferences_key, "");
-			content = new JSONObject(json_string);
-		}
-		
-		return content;
-	}
-	
-	/*
-	 * This method defaults to false.
-	 * If you use this method, be sure to fail-closed on false!
-	 * TODO This is obviously less than ideal...solve it!
-	 */
-	public static boolean getBoolFromSharedPref(String shared_preferences_key) {
-		boolean value = false;
-		if ( checkSharedPrefs() ) {
-			value = shared_preferences.getBoolean(shared_preferences_key, false);
-		}
-		return value;
-	}
-
-	/**
-	 * Get an int from SharedPreferences
-	 * 
-	 * @param shared_preferences_key	Key to retrieve
-	 * @return	The value for the key or 0
-	 */
-	protected static int getIntFromSharedPref(String shared_preferences_key) {
-		return shared_preferences.getInt(shared_preferences_key, 0);
-	}
-	
-	protected static boolean sharedPrefContainsKey(String shared_preferences_key) {
-		return shared_preferences.contains(shared_preferences_key);
-	}
-	/*
-	 * This method defaults to false.
-	 * If you use this method, be sure to fail-closed on false!
-	 * TODO This is obviously less than ideal...solve it!
-	 */
-	public static boolean removeFromSharedPref(String shared_preferences_key) {
-		SharedPreferences.Editor shared_preferences_editor = shared_preferences
-				.edit();
-		shared_preferences_editor.remove(shared_preferences_key);
-		return shared_preferences_editor.commit();
-	}
 	
 	public static boolean checkErroneousDownload(String downloaded_string) {
 		try {
@@ -213,15 +83,6 @@ public class ConfigHelper {
 		byte[] ret = new byte[len - i];
 		System.arraycopy(in, i, ret, 0, len - i);
 		return ret;
-	}
-
-	/**
-	 * Sets class scope Shared Preferences
-	 * @param shared_preferences
-	 */
-	public static void setSharedPreferences(
-			SharedPreferences shared_preferences) {
-		ConfigHelper.shared_preferences = shared_preferences;
 	}
 	
 	public static X509Certificate parseX509CertificateFromString(String certificate_string) {

--- a/src/se/leap/bitmaskclient/Dashboard.java
+++ b/src/se/leap/bitmaskclient/Dashboard.java
@@ -60,10 +60,7 @@ public class Dashboard extends Activity implements LogInDialog.LogInDialogInterf
 	private static final String TAG_EIP_FRAGMENT = "EIP_DASHBOARD_FRAGMENT";
     final public static String SHARED_PREFERENCES = "LEAPPreferences";
     final public static String ACTION_QUIT = "quit";
-	public static final String REQUEST_CODE = "request_code";
-
-
-	
+	public static final String REQUEST_CODE = "request_code";	
 	
 	private ProgressBar mProgressBar;
 	private TextView eipStatus;
@@ -90,11 +87,10 @@ public class Dashboard extends Activity implements LogInDialog.LogInDialogInterf
 
 	    mProgressBar = (ProgressBar) findViewById(R.id.eipProgress);
 	    
-		ConfigHelper.setSharedPreferences(getSharedPreferences(SHARED_PREFERENCES, MODE_PRIVATE));
-		preferences = ConfigHelper.shared_preferences;
+	    preferences = getSharedPreferences(SHARED_PREFERENCES, MODE_PRIVATE);
 
-		authed_eip = ConfigHelper.getBoolFromSharedPref(EIP.AUTHED_EIP);
-		if (ConfigHelper.getStringFromSharedPref(Provider.KEY).isEmpty())
+	    authed_eip = preferences.getBoolean(EIP.AUTHED_EIP, false);
+		if (preferences.getString(Provider.KEY, "").isEmpty())
 			startActivityForResult(new Intent(this,ConfigurationWizard.class),CONFIGURE_LEAP);
 		else
 			buildDashboard();
@@ -110,9 +106,8 @@ public class Dashboard extends Activity implements LogInDialog.LogInDialogInterf
 		if ( requestCode == CONFIGURE_LEAP || requestCode == SWITCH_PROVIDER) {
 		// It should be equivalent: if ( (requestCode == CONFIGURE_LEAP) || (data!= null && data.hasExtra(STOP_FIRST))) {
 			if ( resultCode == RESULT_OK ){		
-				ConfigHelper.saveSharedPref(EIP.PARSED_SERIAL, 0);
-				ConfigHelper.saveSharedPref(EIP.AUTHED_EIP, authed_eip);
-
+				getSharedPreferences(Dashboard.SHARED_PREFERENCES, MODE_PRIVATE).edit().putInt(EIP.PARSED_SERIAL, 0).commit();
+				getSharedPreferences(Dashboard.SHARED_PREFERENCES, MODE_PRIVATE).edit().putBoolean(EIP.AUTHED_EIP, authed_eip).commit();
 				startService( new Intent(EIP.ACTION_UPDATE_EIP_SERVICE) );
 				buildDashboard();
 
@@ -181,8 +176,9 @@ public class Dashboard extends Activity implements LogInDialog.LogInDialogInterf
 	public boolean onPrepareOptionsMenu(Menu menu) {
 		JSONObject provider_json;
 		try {
-			provider_json = ConfigHelper.getJsonFromSharedPref(Provider.KEY);
+			provider_json = new JSONObject(getSharedPreferences(SHARED_PREFERENCES, MODE_PRIVATE).getString(Provider.KEY, ""));
 			JSONObject service_description = provider_json.getJSONObject(Provider.SERVICE);
+			
 			if(service_description.getBoolean(Provider.ALLOW_REGISTRATION)) {
 				if(authed_eip) {
 					menu.findItem(R.id.login_button).setVisible(false);
@@ -219,12 +215,12 @@ public class Dashboard extends Activity implements LogInDialog.LogInDialogInterf
 			return true;
 		case R.id.switch_provider:
 			if (Provider.getInstance().hasEIP()){
-				if (ConfigHelper.getBoolFromSharedPref(EIP.AUTHED_EIP)){
+				if (getSharedPreferences(Dashboard.SHARED_PREFERENCES, MODE_PRIVATE).getBoolean(EIP.AUTHED_EIP, false)){
 					logOut();
 				}
 				eipStop();
 			}
-			ConfigHelper.removeFromSharedPref(Provider.KEY);
+			getSharedPreferences(Dashboard.SHARED_PREFERENCES, MODE_PRIVATE).edit().remove(Provider.KEY).commit();
 			startActivityForResult(new Intent(this,ConfigurationWizard.class), SWITCH_PROVIDER);
 			return true;
 		case R.id.login_button:
@@ -354,7 +350,8 @@ public class Dashboard extends Activity implements LogInDialog.LogInDialogInterf
 			setResult(RESULT_OK);
 
 			authed_eip = true;
-			ConfigHelper.saveSharedPref(EIP.AUTHED_EIP, authed_eip);
+			getSharedPreferences(Dashboard.SHARED_PREFERENCES, MODE_PRIVATE).edit().putBoolean(EIP.AUTHED_EIP, authed_eip).commit();
+
 			invalidateOptionsMenu();
 
         	mProgressBar.setVisibility(ProgressBar.GONE);
@@ -367,7 +364,7 @@ public class Dashboard extends Activity implements LogInDialog.LogInDialogInterf
         	mProgressBar.setVisibility(ProgressBar.GONE);
 		} else if(resultCode == ProviderAPI.LOGOUT_SUCCESSFUL) {
 			authed_eip = false;
-			ConfigHelper.saveSharedPref(EIP.AUTHED_EIP, authed_eip);
+			getSharedPreferences(Dashboard.SHARED_PREFERENCES, MODE_PRIVATE).edit().putBoolean(EIP.AUTHED_EIP, authed_eip).commit();
 
 			changeStatusMessage(resultCode);
 			mProgressBar.setVisibility(ProgressBar.GONE);

--- a/src/se/leap/bitmaskclient/EIP.java
+++ b/src/se/leap/bitmaskclient/EIP.java
@@ -96,13 +96,7 @@ public final class EIP extends IntentService {
 		
 		context = getApplicationContext();
 		
-		try {
-			eipDefinition = ConfigHelper.getJsonFromSharedPref(KEY);
-			parsedEipSerial = ConfigHelper.getIntFromSharedPref(PARSED_SERIAL);
-		} catch (JSONException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
+		updateEIPService();
 		
 		this.retreiveVpnService();
 	}
@@ -250,8 +244,8 @@ public final class EIP extends IntentService {
 	 */
 	private void updateEIPService() {
 		try {
-			eipDefinition = ConfigHelper.getJsonFromSharedPref(EIP.KEY);
-			parsedEipSerial = ConfigHelper.getIntFromSharedPref(PARSED_SERIAL);
+			eipDefinition = new JSONObject(getSharedPreferences(Dashboard.SHARED_PREFERENCES, MODE_PRIVATE).getString(KEY, ""));
+			parsedEipSerial = getSharedPreferences(Dashboard.SHARED_PREFERENCES, MODE_PRIVATE).getInt(PARSED_SERIAL, 0);
 		} catch (JSONException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -315,8 +309,7 @@ public final class EIP extends IntentService {
 				e.printStackTrace();
 			}
 		}
-		
-		ConfigHelper.saveSharedPref(PARSED_SERIAL, eipDefinition.optInt(Provider.API_RETURN_SERIAL));
+		getSharedPreferences(Dashboard.SHARED_PREFERENCES, MODE_PRIVATE).edit().putInt(PARSED_SERIAL, eipDefinition.optInt(Provider.API_RETURN_SERIAL)).commit();
 	}
 
 	/**

--- a/src/se/leap/bitmaskclient/LeapHttpClient.java
+++ b/src/se/leap/bitmaskclient/LeapHttpClient.java
@@ -34,7 +34,6 @@ import android.content.Context;
  *
  */
 public class LeapHttpClient extends DefaultHttpClient {
-	final Context context;
 
 	private static LeapHttpClient client;
 
@@ -43,10 +42,8 @@ public class LeapHttpClient extends DefaultHttpClient {
 	 * @param context
 	 * @return the new client.
 	 */
-	public static LeapHttpClient getInstance(Context context) {
+	public static LeapHttpClient getInstance(String cert_string) {
 		if(client == null) {
-			client = new LeapHttpClient(context);
-			String cert_string = ConfigHelper.getStringFromSharedPref(Provider.CA_CERT);
 			if(cert_string != null) {
 				ConfigHelper.addTrustedCertificate("provider_ca_certificate", cert_string);
 			}
@@ -76,9 +73,5 @@ public class LeapHttpClient extends DefaultHttpClient {
 		} catch (Exception e) {
 			throw new AssertionError(e);
 		}
-	}
-
-	public LeapHttpClient(Context context) {
-		this.context = context;
 	}
 }

--- a/src/se/leap/bitmaskclient/ProviderDetailFragment.java
+++ b/src/se/leap/bitmaskclient/ProviderDetailFragment.java
@@ -11,6 +11,7 @@ import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
 import android.content.DialogInterface;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -28,7 +29,7 @@ public class ProviderDetailFragment extends DialogFragment {
 			LayoutInflater inflater = getActivity().getLayoutInflater();
 			View provider_detail_view = inflater.inflate(R.layout.provider_detail_fragment, null);
 			
-			JSONObject provider_json = ConfigHelper.getJsonFromSharedPref(Provider.KEY);
+			JSONObject provider_json = new JSONObject(getActivity().getSharedPreferences(Dashboard.SHARED_PREFERENCES, getActivity().MODE_PRIVATE).getString(Provider.KEY, ""));
 			
 			final TextView domain = (TextView)provider_detail_view.findViewById(R.id.provider_detail_domain);
 			domain.setText(provider_json.getString(Provider.DOMAIN));
@@ -83,10 +84,8 @@ public class ProviderDetailFragment extends DialogFragment {
 	@Override
 	public void onCancel(DialogInterface dialog) {
 		super.onCancel(dialog);
-		ConfigHelper.removeFromSharedPref(Provider.KEY);
-		ConfigHelper.removeFromSharedPref(ProviderItem.DANGER_ON);
-		ConfigHelper.removeFromSharedPref(EIP.ALLOWED_ANON);
-		ConfigHelper.removeFromSharedPref(EIP.KEY);
+		SharedPreferences.Editor editor = getActivity().getSharedPreferences(Dashboard.SHARED_PREFERENCES, Activity.MODE_PRIVATE).edit();
+		editor.remove(Provider.KEY).remove(ProviderItem.DANGER_ON).remove(EIP.ALLOWED_ANON).remove(EIP.KEY).commit();
 		interface_with_configuration_wizard.showAllProviders();
 	}
 

--- a/src/se/leap/openvpn/VpnProfile.java
+++ b/src/se/leap/openvpn/VpnProfile.java
@@ -22,6 +22,7 @@ import org.spongycastle.util.io.pem.PemObject;
 import org.spongycastle.util.io.pem.PemWriter;
 
 import se.leap.bitmaskclient.ConfigHelper;
+import se.leap.bitmaskclient.Dashboard;
 import se.leap.bitmaskclient.EIP;
 import se.leap.bitmaskclient.Provider;
 import se.leap.bitmaskclient.R;
@@ -249,9 +250,10 @@ public class VpnProfile implements  Serializable{
 			cfg+=insertFileData("cert",mClientCertFilename);
 */
 			// FIXME This is all we need...The whole switch statement can go...
-			cfg+="<ca>\n"+ConfigHelper.getStringFromSharedPref(Provider.CA_CERT)+"\n</ca>\n";
-			cfg+="<key>\n"+ConfigHelper.getStringFromSharedPref(EIP.PRIVATE_KEY)+"\n</key>\n";
-			cfg+="<cert>\n"+ConfigHelper.getStringFromSharedPref(EIP.CERTIFICATE)+"\n</cert>\n";
+			SharedPreferences preferences = context.getSharedPreferences(Dashboard.SHARED_PREFERENCES, context.MODE_PRIVATE);
+			cfg+="<ca>\n"+preferences.getString(Provider.CA_CERT, "")+"\n</ca>\n";
+			cfg+="<key>\n"+preferences.getString(EIP.PRIVATE_KEY, "")+"\n</key>\n";
+			cfg+="<cert>\n"+preferences.getString(EIP.CERTIFICATE, "")+"\n</cert>\n";
 			
 			break;
 		case VpnProfile.TYPE_USERPASS_PKCS12:


### PR DESCRIPTION
This means we obtain the SharedPreferences object each time we want to
use it. This yields to longer code lines while reading and writing to
them.
