### PR TITLE
corrected link for 'building from eclipse' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ signed with a different key.  Manually uninstall Bitmask Android from your devic
 you will then be able to install your own built version.
 To uninstall it, do: adb uninstall se.leap.bitmaskclient
 
-See [here](https://github.com/parmegv/bitmask_android/blob/feature/docs/Building_from_eclipse.md) for
+See [here](https://github.com/leapcode/bitmask_android/blob/develop/Building_from_eclipse.md) for
 instructions on building from [Eclipse](http://eclipse.org).
 
 ## Acknowledgements


### PR DESCRIPTION
Original link for "building from eclipse" pointed at: 
https://github.com/parmegv/bitmask_android/blob/feature/docs/Building_from_eclipse.md
(which is an invalid location)

It has been updated to:
https://github.com/leapcode/bitmask_android/blob/develop/Building_from_eclipse.md
