### PR TITLE
Remove 'Top padding' string from ConfigurationWizard (Bug #5260)

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -94,7 +94,6 @@
     <string name="authed_secured_status">Connection secure using your own certificate.</string>
     <string name="eip_service_label">Encrypted Internet</string>
     <string name="title_activity_configuration_wizard">Select a service provider</string>
-    <string name="top_padding">Top padding</string>
     <string name="new_provider_button">Add new Provider</string>
     <string name="introduce_new_provider">Add a new service provider</string>
     <string name="save">Save</string>

--- a/src/se/leap/bitmaskclient/ConfigurationWizard.java
+++ b/src/se/leap/bitmaskclient/ConfigurationWizard.java
@@ -137,9 +137,9 @@ implements ProviderListFragment.Callbacks, NewProviderDialogInterface, ProviderD
     public void refreshProviderList(int top_padding) {
     	ProviderListFragment new_provider_list_fragment = new ProviderListFragment();
 		Bundle top_padding_bundle = new Bundle();
-		top_padding_bundle.putInt(getResources().getString(R.string.top_padding), top_padding);
+		top_padding_bundle.putInt(ProviderListFragment.TOP_PADDING, top_padding);
 		new_provider_list_fragment.setArguments(top_padding_bundle);
-
+		
 		FragmentManager fragmentManager = getFragmentManager();
 		fragmentManager.beginTransaction()
 		.replace(R.id.configuration_wizard_layout, new_provider_list_fragment, ProviderListFragment.TAG)

--- a/src/se/leap/bitmaskclient/ProviderListFragment.java
+++ b/src/se/leap/bitmaskclient/ProviderListFragment.java
@@ -39,7 +39,7 @@ public class ProviderListFragment extends ListFragment {
 
 	public static String TAG = "provider_list_fragment";
 	public static String SHOW_ALL_PROVIDERS = "show_all_providers";
-	
+	public static String TOP_PADDING = "top padding";
 	private ProviderListAdapter<ProviderItem> content_adapter;
 	
     /**
@@ -120,7 +120,7 @@ public class ProviderListFragment extends ListFragment {
                 && savedInstanceState.containsKey(STATE_ACTIVATED_POSITION)) {
             setActivatedPosition(savedInstanceState.getInt(STATE_ACTIVATED_POSITION));
         }
-    	String top_padding_key = getResources().getString(R.string.top_padding);
+        String top_padding_key = TOP_PADDING;
     	if(getArguments() != null && getArguments().containsKey(top_padding_key)) {
     		int topPadding = getArguments().getInt(top_padding_key);
     		View current_view = getView();


### PR DESCRIPTION
Created a static member "TOP_PADDING" in "ProviderListFragment" class. In "ConfigurationWizard" class referenced "ProviderListFragment.TOP_PADDING" instead of referencing "top_padding" in strings.xml. Also, removed "top_padding" from strings.xml.
