### PR TITLE
Compiles with r9d.

### DIFF
--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,6 +1,6 @@
 APP_ABI := all
-NDK_TOOLCHAIN_VERSION=4.4.3
-#APP_PLATFORM := android-14
+NDK_TOOLCHAIN_VERSION=4.8
+APP_PLATFORM := android-14
 APP_STL:=stlport_static
 
 #APP_OPTIM := release


### PR DESCRIPTION
Tested in emulators with APIs 14, 15, 16 and 18, and in i9100 with API 19.
