### PR TITLE
EIP detection returns false if exception happens.

### DIFF
--- a/src/se/leap/bitmaskclient/Provider.java
+++ b/src/se/leap/bitmaskclient/Provider.java
@@ -168,9 +168,11 @@ public final class Provider implements Serializable {
 					return true;
 			} catch (NullPointerException e){
 				e.printStackTrace();
+				return false;
 			} catch (JSONException e) {
 				// TODO Auto-generated catch block
 				e.printStackTrace();
+				return false;
 			}
 		}
 		return false;


### PR DESCRIPTION
hasEIP method didn't return false if JSONException happened, and that
occurred when a provider didn't offer EIP (right now, cdev doesn't offer
EIP).
