### PR TITLE
Progressbar can be null if there is no EIP service

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -144,4 +144,4 @@ task mergeUntranslatable( type: Copy, dependsOn: 'removeDuplicatedStrings') {
 
   delete ics_openvpn_untranslatable
 }
-build.dependsOn ':app:mergeUntranslatable'
+//build.dependsOn ':app:mergeUntranslatable'

--- a/app/src/main/java/se/leap/bitmaskclient/EipServiceFragment.java
+++ b/app/src/main/java/se/leap/bitmaskclient/EipServiceFragment.java
@@ -221,7 +221,8 @@ public class EipServiceFragment extends Fragment implements StateListener, OnChe
 						mEipStartPending = false;
 					} else if ( level == ConnectionStatus.LEVEL_NONETWORK || level == ConnectionStatus.LEVEL_NOTCONNECTED || level == ConnectionStatus.LEVEL_AUTH_FAILED) {
 						statusMessage = getString(R.string.eip_state_not_connected);
-						getActivity().findViewById(R.id.eipProgress).setVisibility(View.GONE);
+						if(getActivity() != null && getActivity().findViewById(R.id.eipProgress) != null)
+						    getActivity().findViewById(R.id.eipProgress).setVisibility(View.GONE);
 						mEipStartPending = false;
 						switchState = false;
 					} else if (level == ConnectionStatus.LEVEL_CONNECTING_SERVER_REPLIED) {


### PR DESCRIPTION
This happens when you've used a eip enabled provider, and then you
switch to a non eip enabled one (e.g., choosing demo.bitmask.net and
then switching to cdev.bitmask.net in their current configurations).

I've also disabled the build task dependency on updating
ics-openvpn. It's causing problems, while not fixing anything.
