### PR TITLE
provider.json is downloaded before ca.crt

### DIFF
--- a/app/src/debug/java/se/leap/bitmaskclient/ProviderAPI.java
+++ b/app/src/debug/java/se/leap/bitmaskclient/ProviderAPI.java
@@ -426,7 +426,7 @@ public class ProviderAPI extends IntentService {
 	parameters.put("user[password_verifier]", password_verifier);
 	Log.d(TAG, server_url);
 	Log.d(TAG, parameters.toString());
-	return sendToServer(server_url + "/users", "POST", parameters);
+	return sendToServer(server_url + "/users.json", "POST", parameters);
     }
 	
 	/**
@@ -538,16 +538,16 @@ public class ProviderAPI extends IntentService {
 			CA_CERT_DOWNLOADED = PROVIDER_JSON_DOWNLOADED = EIP_SERVICE_JSON_DOWNLOADED = false;
 		}
 
-		if(!CA_CERT_DOWNLOADED)
-			current_download = downloadCACert(last_provider_main_url, last_danger_on);
-		if(CA_CERT_DOWNLOADED || (current_download.containsKey(RESULT_KEY) && current_download.getBoolean(RESULT_KEY))) {
-			broadcast_progress(progress++);
-			CA_CERT_DOWNLOADED = true;
 			if(!PROVIDER_JSON_DOWNLOADED)
 				current_download = getAndSetProviderJson(last_provider_main_url, last_danger_on);
 			if(PROVIDER_JSON_DOWNLOADED || (current_download.containsKey(RESULT_KEY) && current_download.getBoolean(RESULT_KEY))) {
+			    broadcast_progress(progress++);
+			    PROVIDER_JSON_DOWNLOADED = true;
+			    current_download = downloadCACert(last_danger_on);
+			    
+			    if(CA_CERT_DOWNLOADED || (current_download.containsKey(RESULT_KEY) && current_download.getBoolean(RESULT_KEY))) {
 				broadcast_progress(progress++);
-				PROVIDER_JSON_DOWNLOADED = true;
+				CA_CERT_DOWNLOADED = true;
 				current_download = getAndSetEipServiceJson(); 
 				if(current_download.containsKey(RESULT_KEY) && current_download.getBoolean(RESULT_KEY)) {
 					broadcast_progress(progress++);
@@ -559,17 +559,25 @@ public class ProviderAPI extends IntentService {
 		return current_download;
 	}
 	
-	private Bundle downloadCACert(String provider_main_url, boolean danger_on) {
+	private Bundle downloadCACert(boolean danger_on) {
 		Bundle result = new Bundle();
-		String cert_string = downloadWithCommercialCA(provider_main_url + "/ca.crt", danger_on);
+		try {
+		    JSONObject provider_json = new JSONObject(getSharedPreferences(Dashboard.SHARED_PREFERENCES, MODE_PRIVATE).getString(Provider.KEY, ""));
+		    String ca_cert_url = provider_json.getString(Provider.CA_CERT_URI);
+		    String cert_string = downloadWithCommercialCA(ca_cert_url, danger_on);
 
-	    if(validCertificate(cert_string) && setting_up_provider) {
-	    	getSharedPreferences(Dashboard.SHARED_PREFERENCES, MODE_PRIVATE).edit().putString(Provider.CA_CERT, cert_string).commit();
+		    if(validCertificate(cert_string) && setting_up_provider) {
+			getSharedPreferences(Dashboard.SHARED_PREFERENCES, MODE_PRIVATE).edit().putString(Provider.CA_CERT, cert_string).commit();
 			result.putBoolean(RESULT_KEY, true);
-		} else {
+		    } else {
 			String reason_to_fail = pickErrorMessage(cert_string);
 			result.putString(ERRORS, reason_to_fail);
 			result.putBoolean(RESULT_KEY, false);
+		    }
+		} catch (JSONException e) {
+		    String reason_to_fail = formatErrorMessage(R.string.malformed_url);
+		    result.putString(ERRORS, reason_to_fail);
+		    result.putBoolean(RESULT_KEY, false);
 		}
 		
 		return result;

--- a/app/src/main/java/se/leap/bitmaskclient/Provider.java
+++ b/app/src/main/java/se/leap/bitmaskclient/Provider.java
@@ -51,6 +51,7 @@ public final class Provider implements Serializable {
 	SERVICE = "service",
 	KEY = "provider",
 	CA_CERT = "ca_cert",
+	CA_CERT_URI = "ca_cert_uri",
 	NAME = "name",
 	DESCRIPTION = "description",
 	DOMAIN = "domain",


### PR DESCRIPTION
We don't assume ca.crt is in /ca.crt anymore, but fetch the complete url
from provider.json.

We also signup against users.json file instead of simple "users", which
worked for *.bitmask.net domains.
