### PR TITLE
Typo fix

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,7 +60,7 @@
     <string name="signingup_message">Signing up</string>
     <string name="logout_message">Logging out from this session.</string>
     <string name="logged_out_message">Logged out.</string>
-    <string name="log_out_failed_message">Didn\'t logged out.</string>
+    <string name="log_out_failed_message">Didn\'t log out.</string>
     <string name="succesful_authentication_message">Authentication succeeded.</string>
     <string name="authentication_failed_message">Authentication failed.</string>
     <string name="successful_authed_cert_downloaded_message">Your own cert has been correctly downloaded.</string>


### PR DESCRIPTION
Fixed a typo in the strings.xml file. Should be "Didn't log out" not "Didn't logged out" :)
