### PR TITLE
Bitmask does not show the log if an error happens.

### DIFF
--- a/app/src/main/java/se/leap/bitmaskclient/VpnFragment.java
+++ b/app/src/main/java/se/leap/bitmaskclient/VpnFragment.java
@@ -244,10 +244,7 @@ public class VpnFragment extends Fragment implements Observer {
         Context context = dashboard.getApplicationContext();
         String error = eip_status.lastError(5, context);
 
-        if (!error.isEmpty()) {
-            dashboard.showLog();
-            VoidVpnService.stop();
-        }
+        if (!error.isEmpty()) VoidVpnService.stop();
         updateIcon();
         updateButton();
     }


### PR DESCRIPTION
ics-openvpn already shows it if necessary. Our heuristic (just looking
for an "error" keyword in the past N messages of the log) is very weak,
and it returns an annoying false positive: turning off the VPN triggers
the show log error.