### PR TITLE
Fix Riseup VPN URL

### DIFF
--- a/app/assets/urls/riseup.url
+++ b/app/assets/urls/riseup.url
@@ -1,4 +1,4 @@
 {
-	"main_url" : "https://riseup.net/",
-	"ca_cert_fingerprint" : "aef7a642d7f8e046770521b354961a95cd4a76a8"
+	"main_url" : "https://black.riseup.net/",
+	"ca_cert_fingerprint" : "dac9024f54d8f6df94935fb1732638ca6ad77c13"
 }


### PR DESCRIPTION
Updating Riseup address and fingerprint so VPN connection works.

Riseup have changed their URL to:
https://black.riseup.net/

However, this is apparently causing DNS leaks #226 
